### PR TITLE
download_video_actors not working

### DIFF
--- a/dword/core.py
+++ b/dword/core.py
@@ -183,7 +183,7 @@ class DeepWord:
             for dic in self._process_output(response.text)['sample_video_files']:
                 with self.session.get(dic['video_url'], stream=True) as r:
                     r.raise_for_status()
-                    fname = path / folder / (dic['title']+dic['extension'])
+                    fname = path / folder / (dic['name']+dic['extension'])
                     with open(fname, 'wb') as f:
                         for chunk in r.iter_content(chunk_size=8192):
                             f.write(chunk)


### PR DESCRIPTION
changed 'title' to 'name' in the script and it started to work. Might be better to change the server response to have title instead of name in the properties.